### PR TITLE
docs: add 'Arquitetura Recomendada' section + align all skills + service layer refactor

### DIFF
--- a/.opencode/skills/domain-admin-panel/SKILL.md
+++ b/.opencode/skills/domain-admin-panel/SKILL.md
@@ -15,6 +15,68 @@ Caso real: você vai vender um SaaS feito com este template. O cliente final **n
 
 Esta skill cobre **o gap** que o template original tem: tudo de auth/user CRUD hoje depende do admin PB nativo.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Store `admin` consome `adminService`, nunca `pb` direto |
+| 2 — Service thin + hook | CRUD de users direto; invite/reset/impersonate via endpoints custom (hooks) |
+| 3 — Backend é a verdade | Collection rules por role (`isAdmin`); hooks protegem último admin e auto-edição |
+| 4 — Vertical slicing | Estrutura `features/admin-panel/{users,invites,audit}/` |
+| 5 — Type-safety | Tipos via `@pb-types` (`UsersRecord`, `InvitesRecord`, `AuditLogRecord`) |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/admin-panel/services/admin.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { UsersRecord, AuditLogRecord } from '@pb-types'
+
+export const adminService = {
+  // CRUD — Padrão 1 + 2
+  async listUsers(page = 1, perPage = 200) {
+    return pb.collection('users').getList<UsersRecord>(page, perPage, {
+      sort: '-created', expand: 'team,created_by',
+    })
+  },
+  async getUser(id: string) {
+    return pb.collection('users').getOne<UsersRecord>(id)
+  },
+  async updateUser(id: string, data: Partial<UsersRecord>) {
+    return pb.collection('users').update<UsersRecord>(id, data)
+  },
+  async deleteUser(id: string) {
+    return pb.collection('users').delete(id)
+  },
+  async listAuditLog(page = 1, perPage = 50) {
+    return pb.collection('audit_log').getList<AuditLogRecord>(page, perPage, {
+      sort: '-created', expand: 'actor',
+    })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoints custom protegidos por $apis.requireSuperuserAuth)
+  async createUser(data: { email: string; name?: string; role: string; password?: string }) {
+    return pb.send('/api/admin/users', { method: 'POST', body: JSON.stringify(data) })
+  },
+  async invite(data: { email: string; role: string }) {
+    return pb.send('/api/admin/invites', { method: 'POST', body: JSON.stringify(data) })
+  },
+  async resetPassword(userId: string) {
+    return pb.send(`/api/admin/users/${userId}/reset-password`, { method: 'POST' })
+  },
+  async impersonate(userId: string) {
+    return pb.send(`/api/admin/users/${userId}/impersonate`, { method: 'POST' })
+  },
+  async validateInviteToken(token: string) {
+    return pb.send(`/api/invites/${token}`)
+  },
+}
+```
+
+> 📖 Detalhes do padrão service layer na skill [`vue-pinia-store`](../vue-pinia-store/SKILL.md). Esta skill depende fortemente de `domain-rbac` pra matriz de permissões.
+
 ## Visão do domínio
 
 ```

--- a/.opencode/skills/domain-admin-panel/SKILL.md
+++ b/.opencode/skills/domain-admin-panel/SKILL.md
@@ -350,37 +350,87 @@ routerAdd('POST', '/api/admin/users/:id/impersonate', (c) => {
 | `audit_log`  | admin only                     | admin only        | server-only (hooks) | admin only         | never (append-only) |
 | `teams`      | `""` (qualquer logado)          | mesmo             | admin      | admin                       | admin              |
 
-## 4. Pinia store
+## 4. Pinia store (via service layer — Padrão 1)
 
-`apps/web/src/stores/admin.ts`:
+### Service (camada que fala com pb)
 
 ```ts
+// apps/web/src/features/admin-panel/services/admin.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { UsersRecord, AuditLogRecord, InvitesRecord } from '@pb-types'
+
+export const adminService = {
+  // CRUD — Padrão 1 + 2
+  async listUsers(page = 1, perPage = 200) {
+    return pb.collection('users').getList<UsersRecord>(page, perPage, {
+      sort: '-created', expand: 'team,created_by',
+    })
+  },
+  async getUser(id: string) {
+    return pb.collection('users').getOne<UsersRecord>(id)
+  },
+  async updateUser(id: string, data: Partial<UsersRecord>) {
+    return pb.collection('users').update<UsersRecord>(id, data)
+  },
+  async deleteUser(id: string) {
+    return pb.collection('users').delete(id)
+  },
+  async listAuditLog(page = 1, perPage = 50) {
+    return pb.collection('audit_log').getList<AuditLogRecord>(page, perPage, {
+      sort: '-created', expand: 'actor',
+    })
+  },
+  async listInvites(page = 1, perPage = 50) {
+    return pb.collection('invites').getList<InvitesRecord>(page, perPage, {
+      sort: '-created', expand: 'invited_by',
+    })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoints custom protegidos por $apis.requireSuperuserAuth no PB)
+  async createUser(data: { email: string; name?: string; role: string; password?: string }) {
+    return pb.send('/api/admin/users', { method: 'POST', body: JSON.stringify(data) })
+  },
+  async invite(data: { email: string; role: string }) {
+    return pb.send('/api/admin/invites', { method: 'POST', body: JSON.stringify(data) })
+  },
+  async resetPassword(userId: string) {
+    return pb.send(`/api/admin/users/${userId}/reset-password`, { method: 'POST' })
+  },
+  async impersonate(userId: string) {
+    return pb.send(`/api/admin/users/${userId}/impersonate`, { method: 'POST' })
+  },
+  async validateInviteToken(token: string) {
+    return pb.send(`/api/invites/${token}`)
+  },
+}
+```
+
+### Store (consome o service, NUNCA pb direto)
+
+```ts
+// apps/web/src/features/admin-panel/stores/admin.store.ts
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import pb from '@/services/pocketbase'
+import { adminService } from '../services/admin.service'
+import type { UsersRecord, AuditLogRecord } from '@pb-types'
 
-export interface AdminUser {
-  id: string
-  email: string
-  name?: string
-  role: 'admin' | 'manager' | 'member' | 'viewer'
-  status: 'active' | 'invited' | 'suspended'
-  last_login_at?: string
-  created: string
-  expand?: { team?: any; created_by?: any }
-}
+type Role = 'admin' | 'manager' | 'member' | 'viewer'
+type Status = 'active' | 'invited' | 'suspended'
 
 export const useAdminStore = defineStore('admin', () => {
-  const users = ref<AdminUser[]>([])
+  const users = ref<UsersRecord[]>([])
+  const auditEntries = ref<AuditLogRecord[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
   const query = ref('')
-  const roleFilter = ref<'all' | AdminUser['role']>('all')
+  const roleFilter = ref<'all' | Role>('all')
 
   const filtered = computed(() => {
     const q = query.value.toLowerCase().trim()
     return users.value.filter(u => {
-      const matchesQ = !q || u.email.toLowerCase().includes(q) || (u.name?.toLowerCase().includes(q) ?? false)
+      const matchesQ = !q
+        || u.email.toLowerCase().includes(q)
+        || (u.name?.toLowerCase().includes(q) ?? false)
       const matchesR = roleFilter.value === 'all' || u.role === roleFilter.value
       return matchesQ && matchesR
     })
@@ -388,57 +438,54 @@ export const useAdminStore = defineStore('admin', () => {
 
   async function fetchUsers() {
     loading.value = true
+    error.value = null
     try {
-      const res = await pb.collection('users').getList<AdminUser>(1, 200, {
-        sort: '-created', expand: 'team,created_by',
-      })
+      const res = await adminService.listUsers()
       users.value = res.items
-    } catch (e: any) { error.value = e?.message } finally { loading.value = false }
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao buscar usuários'
+    } finally {
+      loading.value = false
+    }
   }
 
   async function createUser(data: { email: string; name?: string; role: string; password?: string }) {
-    const tempPass = data.password || Math.random().toString(36).slice(-12)
-    const created = await pb.collection('users').create({
-      email: data.email, name: data.name, role: data.role, status: 'active',
-      password: tempPass, passwordConfirm: tempPass,
-    })
-    users.value.unshift(created)
-    return { user: created, tempPassword: tempPass }
+    const result = await adminService.createUser(data) as { user: UsersRecord; tempPassword: string }
+    users.value.unshift(result.user)
+    return result
   }
 
-  async function updateUser(id: string, data: Partial<AdminUser>) {
-    const updated = await pb.collection('users').update(id, data)
+  async function updateUser(id: string, data: Partial<UsersRecord>) {
+    const updated = await adminService.updateUser(id, data)
     const i = users.value.findIndex(u => u.id === id)
     if (i >= 0) users.value[i] = updated
     return updated
   }
 
-  async function suspend(id: string) {
-    return updateUser(id, { status: 'suspended' })
-  }
-  async function reactivate(id: string) {
-    return updateUser(id, { status: 'active' })
-  }
+  async function suspend(id: string) { return updateUser(id, { status: 'suspended' as Status }) }
+  async function reactivate(id: string) { return updateUser(id, { status: 'active' as Status }) }
 
   async function deleteUser(id: string) {
-    await pb.collection('users').delete(id)
+    await adminService.deleteUser(id)
     users.value = users.value.filter(u => u.id !== id)
   }
 
   async function invite(data: { email: string; role: string }) {
-    return pb.send('/api/admin/invites', { method: 'POST', body: JSON.stringify(data) })
+    return adminService.invite(data)
   }
 
-  async function resetPassword(id: string) {
-    return pb.send('/api/admin/users/' + id + '/reset-password', { method: 'POST' })
+  async function resetPassword(userId: string) {
+    return adminService.resetPassword(userId)
   }
 
-  async function fetchAuditLog(page = 1) {
-    return pb.collection('audit_log').getList(1, 50, { sort: '-created', expand: 'actor' })
+  async function fetchAuditLog() {
+    const res = await adminService.listAuditLog()
+    auditEntries.value = res.items
+    return res
   }
 
   return {
-    users, loading, error, query, roleFilter, filtered,
+    users, auditEntries, loading, error, query, roleFilter, filtered,
     fetchUsers, createUser, updateUser, suspend, reactivate, deleteUser,
     invite, resetPassword, fetchAuditLog,
   }

--- a/.opencode/skills/domain-blog-cms/SKILL.md
+++ b/.opencode/skills/domain-blog-cms/SKILL.md
@@ -7,6 +7,59 @@ description: Como adicionar um Blog/CMS completo (posts, categorias, tags, autor
 
 Caso real: app com área de conteúdo (blog, knowledge base, changelog, docs).
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Store de `posts` consome service, nunca `pb` direto |
+| 2 — Service thin + hook | CRUD direto no service; contador de views e slug auto-gerado via hooks |
+| 3 — Backend é a verdade | `posts` filtra por `status = "published" \|\| author = @request.auth.id` |
+| 4 — Vertical slicing | Estrutura `features/blog/{posts,categories,tags,comments}/` |
+| 5 — Type-safety | Tipos via `@pb-types` (`PostsRecord`, `CategoriesRecord`, `CommentsRecord`) |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/blog/posts/services/posts.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PostsRecord } from '@pb-types'
+
+export const postsService = {
+  // CRUD — Padrão 1 + 2
+  async listPublished(page = 1, perPage = 12) {
+    return pb.collection('posts').getList<PostsRecord>(page, perPage, {
+      filter: 'status = "published"',
+      sort: '-published_at',
+      expand: 'author,category,tags',
+    })
+  },
+  async getBySlug(slug: string) {
+    return pb.collection('posts').getFirstListItem<PostsRecord>(
+      `slug = "${slug}" && status = "published"`,
+      { expand: 'author,category,tags' }
+    )
+  },
+  async create(data: Partial<PostsRecord>) {
+    return pb.collection('posts').create<PostsRecord>(data)
+  },
+  async update(id: string, data: Partial<PostsRecord>) {
+    return pb.collection('posts').update<PostsRecord>(id, data)
+  },
+  async delete(id: string) {
+    return pb.collection('posts').delete(id)
+  },
+
+  // Lógica avançada — Padrão 2 (endpoint custom no PB)
+  async incrementView(postId: string) {
+    return pb.send(`/api/posts/${postId}/view`, { method: 'POST' })
+  },
+}
+```
+
+> 📖 Detalhes do padrão service layer na skill [`vue-pinia-store`](../vue-pinia-store/SKILL.md).
+
 ## Visão do domínio
 
 ```

--- a/.opencode/skills/domain-blog-cms/SKILL.md
+++ b/.opencode/skills/domain-blog-cms/SKILL.md
@@ -261,78 +261,137 @@ onRecordBeforeCreateRequest((e) => {
 }, $app)
 ```
 
-## 3. Stores Pinia
+## 3. Stores Pinia (via service layer — Padrão 1)
 
-### `apps/web/src/stores/posts.ts`
+### Service (camada que fala com pb)
 
 ```ts
-import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
-import pb from '@/services/pocketbase'
+// apps/web/src/features/blog/posts/services/posts.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PostsRecord } from '@pb-types'
 
-export interface Post {
-  id: string
-  title: string
-  slug: string
-  excerpt: string
-  content: string
-  status: 'draft' | 'published' | 'archived'
-  published_at: string
-  author: string
-  category: string
-  tags: string[]
-  reading_time: number
-  views: number
-  cover_image?: string
-  expand?: { author?: any; category?: any; tags?: any[] }
+export interface PostFilters {
+  page?: number
+  perPage?: number
+  tag?: string
+  category?: string
 }
 
-export const usePostsStore = defineStore('posts', () => {
-  const items = ref<Post[]>([])
-  const current = ref<Post | null>(null)
-  const loading = ref(false)
+export const postsService = {
+  // CRUD — Padrão 1 + 2 (thin wrapper)
+  async listPublished(filters: PostFilters = {}) {
+    const filter: string[] = ['status = "published"']
+    if (filters.tag)      filter.push(`tags ?~ "${filters.tag}"`)
+    if (filters.category) filter.push(`category = "${filters.category}"`)
 
-  async function fetchPublished(params: { page?: number; perPage?: number; tag?: string; category?: string } = {}) {
-    loading.value = true
-    try {
-      const filter: string[] = [`status = "published"`]
-      if (params.tag)      filter.push(`tags ?~ "${params.tag}"`)
-      if (params.category) filter.push(`category = "${params.category}"`)
-
-      const res = await pb.collection('posts').getList<Post>(params.page ?? 1, params.perPage ?? 12, {
+    return pb.collection('posts').getList<PostsRecord>(
+      filters.page ?? 1,
+      filters.perPage ?? 12,
+      {
         filter: filter.join(' && '),
         sort: '-published_at',
         expand: 'author,category,tags',
-      })
+      },
+    )
+  },
+
+  async getBySlug(slug: string) {
+    return pb.collection('posts').getFirstListItem<PostsRecord>(
+      `slug = "${slug}" && status = "published"`,
+      { expand: 'author,category,tags' },
+    )
+  },
+
+  async create(data: Partial<PostsRecord>) {
+    return pb.collection('posts').create<PostsRecord>(data)
+  },
+
+  async update(id: string, data: Partial<PostsRecord>) {
+    return pb.collection('posts').update<PostsRecord>(id, data)
+  },
+
+  async delete(id: string) {
+    return pb.collection('posts').delete(id)
+  },
+
+  // Lógica avançada — Padrão 2 (endpoint custom)
+  async incrementView(postId: string) {
+    return pb.send(`/api/posts/${postId}/view`, { method: 'POST' })
+  },
+}
+```
+
+### Store (consome o service, NUNCA pb direto)
+
+```ts
+// apps/web/src/features/blog/posts/stores/posts.store.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { postsService, type PostFilters } from '../services/posts.service'
+import type { PostsRecord } from '@pb-types'
+
+export const usePostsStore = defineStore('posts', () => {
+  const items = ref<PostsRecord[]>([])
+  const current = ref<PostsRecord | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchPublished(filters: PostFilters = {}) {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await postsService.listPublished(filters)
       items.value = res.items
       return res
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao buscar posts'
+      throw e
     } finally {
       loading.value = false
     }
   }
 
   async function fetchBySlug(slug: string) {
-    const rec = await pb.collection('posts').getFirstListItem<Post>(`slug = "${slug}" && status = "published"`, {
-      expand: 'author,category,tags',
-    })
-    current.value = rec
-    // incrementa view (rota custom do hook)
-    pb.send('/api/posts/' + rec.id + '/view', { method: 'POST' }).catch(() => {})
-    return rec
+    loading.value = true
+    try {
+      const rec = await postsService.getBySlug(slug)
+      current.value = rec
+      // incrementa view (rota custom do hook) — fire-and-forget
+      postsService.incrementView(rec.id).catch(() => {})
+      return rec
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Post não encontrado'
+      throw e
+    } finally {
+      loading.value = false
+    }
   }
 
-  async function create(data: Partial<Post>) {
-    const rec = await pb.collection('posts').create(data)
-    return rec
+  async function create(data: Partial<PostsRecord>) {
+    const created = await postsService.create(data)
+    items.value.unshift(created)
+    return created
   }
 
-  async function update(id: string, data: Partial<Post>) {
-    return pb.collection('posts').update(id, data)
+  async function update(id: string, data: Partial<PostsRecord>) {
+    const updated = await postsService.update(id, data)
+    const i = items.value.findIndex(p => p.id === id)
+    if (i >= 0) items.value[i] = updated
+    if (current.value?.id === id) current.value = updated
+    return updated
   }
 
-  return { items, current, loading, fetchPublished, fetchBySlug, create, update }
+  async function remove(id: string) {
+    await postsService.delete(id)
+    items.value = items.value.filter(p => p.id !== id)
+    if (current.value?.id === id) current.value = null
+  }
+
+  return { items, current, loading, error, fetchPublished, fetchBySlug, create, update, remove }
 })
 ```
+
+> 📖 Esse padrão (service + store) é a **implementação canônica** do Padrão 1. Veja [`domain-feature-scaffold`](../domain-feature-scaffold/SKILL.md) pra receita completa.
 
 ## 4. Router
 

--- a/.opencode/skills/domain-crm-leads/SKILL.md
+++ b/.opencode/skills/domain-crm-leads/SKILL.md
@@ -216,40 +216,85 @@ onRecordAfterUpdateRequest((e) => {
 }, $app)
 ```
 
-## 3. Pinia Store
+## 3. Pinia Store (via service layer — Padrão 1)
 
-`apps/web/src/stores/leads.ts`:
+### Service de leads (camada que fala com pb)
 
 ```ts
-import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
-import pb from '@/services/pocketbase'
+// apps/web/src/features/crm/leads/services/leads.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { LeadsRecord } from '@pb-types'
 
 export type LeadStatus = 'new' | 'contacted' | 'qualified' | 'proposal' | 'negotiation' | 'won' | 'lost'
-export interface Lead {
-  id: string
-  name: string
-  email?: string
-  phone?: string
-  company?: string
-  status: LeadStatus
-  estimated_value?: number
-  owner?: string
-  // ... outros campos
+
+export const leadsService = {
+  // CRUD — Padrão 1 + 2
+  async list(page = 1, perPage = 200) {
+    return pb.collection('leads').getList<LeadsRecord>(page, perPage, {
+      sort: '-created', expand: 'owner',
+    })
+  },
+  async getById(id: string) {
+    return pb.collection('leads').getOne<LeadsRecord>(id)
+  },
+  async create(data: Partial<LeadsRecord>) {
+    return pb.collection('leads').create<LeadsRecord>(data)
+  },
+  async update(id: string, data: Partial<LeadsRecord>) {
+    return pb.collection('leads').update<LeadsRecord>(id, data)
+  },
+  async delete(id: string) {
+    return pb.collection('leads').delete(id)
+  },
+  async listByStatus(status: LeadStatus) {
+    return pb.collection('leads').getFullList<LeadsRecord>({
+      filter: `status = "${status}"`, sort: '-created', expand: 'owner',
+    })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoint custom no PB)
+  async convertToClient(leadId: string) {
+    return pb.send(`/api/leads/${leadId}/convert`, { method: 'POST' })
+  },
 }
+```
+
+### Service realtime (subscribe encapsulado)
+
+```ts
+// apps/web/src/features/crm/leads/services/leads.realtime.ts
+import { realtimeService } from '@/shared/services/realtime.service'
+import type { LeadsRecord } from '@pb-types'
+
+export const leadsRealtime = {
+  subscribe(handler: (e: { action: 'create' | 'update' | 'delete'; record: LeadsRecord }) => void) {
+    return realtimeService.subscribe<LeadsRecord>('leads', handler)
+  },
+}
+```
+
+### Store (consome o service, NUNCA pb direto)
+
+```ts
+// apps/web/src/features/crm/leads/stores/leads.store.ts
+import { defineStore } from 'pinia'
+import { ref, computed, onUnmounted } from 'vue'
+import { leadsService, type LeadStatus } from '../services/leads.service'
+import { leadsRealtime } from '../services/leads.realtime'
+import type { LeadsRecord } from '@pb-types'
 
 export const useLeadsStore = defineStore('leads', () => {
-  const items = ref<Lead[]>([])
+  const items = ref<LeadsRecord[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
   const filter = ref<LeadStatus | 'all'>('all')
 
   const filtered = computed(() =>
-    filter.value === 'all' ? items.value : items.value.filter(l => l.status === filter.value)
+    filter.value === 'all' ? items.value : items.value.filter(l => l.status === filter.value),
   )
 
   const byStatus = computed(() => {
-    const groups: Record<LeadStatus, Lead[]> = {
+    const groups: Record<LeadStatus, LeadsRecord[]> = {
       new: [], contacted: [], qualified: [], proposal: [], negotiation: [], won: [], lost: [],
     }
     for (const l of items.value) groups[l.status]?.push(l)
@@ -260,26 +305,23 @@ export const useLeadsStore = defineStore('leads', () => {
     loading.value = true
     error.value = null
     try {
-      const res = await pb.collection('leads').getList<Lead>(1, 200, {
-        sort: '-created',
-        expand: 'owner',
-      })
+      const res = await leadsService.list()
       items.value = res.items
-    } catch (e: any) {
-      error.value = e?.message || 'Falha ao listar leads'
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao listar leads'
     } finally {
       loading.value = false
     }
   }
 
-  async function create(data: Partial<Lead>) {
-    const created = await pb.collection('leads').create(data)
+  async function create(data: Partial<LeadsRecord>) {
+    const created = await leadsService.create(data)
     items.value.unshift(created)
     return created
   }
 
-  async function update(id: string, data: Partial<Lead>) {
-    const updated = await pb.collection('leads').update(id, data)
+  async function update(id: string, data: Partial<LeadsRecord>) {
+    const updated = await leadsService.update(id, data)
     const idx = items.value.findIndex(l => l.id === id)
     if (idx >= 0) items.value[idx] = updated
     return updated
@@ -290,26 +332,33 @@ export const useLeadsStore = defineStore('leads', () => {
   }
 
   async function remove(id: string) {
-    await pb.collection('leads').delete(id)
+    await leadsService.delete(id)
     items.value = items.value.filter(l => l.id !== id)
   }
 
+  async function convertToClient(id: string) {
+    await leadsService.convertToClient(id)
+    // o hook PB faz o trabalho cross-collection (cria contato, atividade, dispara email)
+    // O realtime traz a atualização de status depois
+  }
+
   // realtime: sincroniza mudanças vindas de outros users
-  pb.collection('leads').subscribe('*', (e) => {
-    if (e.action === 'create') items.value.unshift(e.record as Lead)
+  const unsub = leadsRealtime.subscribe((e) => {
+    if (e.action === 'create') items.value.unshift(e.record)
     else if (e.action === 'update') {
       const idx = items.value.findIndex(l => l.id === e.record.id)
-      if (idx >= 0) items.value[idx] = e.record as Lead
+      if (idx >= 0) items.value[idx] = e.record
     } else if (e.action === 'delete') {
       items.value = items.value.filter(l => l.id !== e.record.id)
     }
   })
 
-  return { items, loading, error, filter, filtered, byStatus, fetchAll, create, update, moveTo, remove }
+  // cleanup automático
+  onUnmounted(() => unsub())
+
+  return { items, loading, error, filter, filtered, byStatus, fetchAll, create, update, moveTo, remove, convertToClient }
 })
 ```
-
-> ⚠️ `pb.collection('leads').subscribe('*')` é o hook realtime do PB — funciona com `domain-realtime` se quiser ir além.
 
 ## 4. Router
 

--- a/.opencode/skills/domain-crm-leads/SKILL.md
+++ b/.opencode/skills/domain-crm-leads/SKILL.md
@@ -9,6 +9,60 @@ Caso real: você tá construindo um CRM. Aqui vai o passo a passo completo pra a
 
 > Esta skill é **end-to-end**: modelagem → hooks → store → UI. Use em conjunto com `vue-pinia-store`, `vue-router-auth`, `tailwind-vue-component` pros detalhes de cada peça.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Stores de `leads`/`contacts`/`activities` consomem service, nunca `pb` direto |
+| 2 — Service thin + hook | CRUD direto no service; "converter lead em cliente" vai via hook custom (`/api/leads/:id/convert`) |
+| 3 — Backend é a verdade | Regras de acesso por ownership + hooks de proteção |
+| 4 — Vertical slicing | Estrutura `features/crm/{leads,contacts,activities}/` |
+| 5 — Type-safety | Tipos via `@pb-types`, zero `any` |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/crm/leads/services/leads.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { LeadsRecord } from '@pb-types'
+
+export const leadsService = {
+  // CRUD — Padrão 1 + 2 (thin wrapper)
+  async list(page = 1, perPage = 50) {
+    return pb.collection('leads').getList<LeadsRecord>(page, perPage)
+  },
+  async getById(id: string) {
+    return pb.collection('leads').getOne<LeadsRecord>(id)
+  },
+  async create(data: Partial<LeadsRecord>) {
+    return pb.collection('leads').create<LeadsRecord>(data)
+  },
+  async update(id: string, data: Partial<LeadsRecord>) {
+    return pb.collection('leads').update<LeadsRecord>(id, data)
+  },
+  async delete(id: string) {
+    return pb.collection('leads').delete(id)
+  },
+
+  // Lógica avançada — Padrão 2 (hook custom no PB)
+  async convertToClient(leadId: string) {
+    return pb.send(`/api/leads/${leadId}/convert`, { method: 'POST' })
+  },
+
+  // Query com filtro do funil
+  async byStatus(status: string) {
+    return pb.collection('leads').getList<LeadsRecord>(1, 200, {
+      filter: `status = "${status}"`,
+      sort: '-created',
+    })
+  },
+}
+```
+
+> 📖 Detalhes do padrão service layer na skill [`vue-pinia-store`](../vue-pinia-store/SKILL.md) e regras de acesso em [`pocketbase-collections`](../pocketbase-collections/SKILL.md).
+
 ## Visão do domínio
 
 ```

--- a/.opencode/skills/domain-email-hooks/SKILL.md
+++ b/.opencode/skills/domain-email-hooks/SKILL.md
@@ -7,6 +7,55 @@ description: Como enviar emails transacionais no template — password reset, ve
 
 PocketBase tem **Mailer** nativo (`$app.newMailClient()`). Pra casos simples, dá pra enviar direto via SMTP. Pra produção, use um provider (Resend, SendGrid, Postmark) através de `$http`.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill é majoritariamente **backend** (hooks PB), mas segue os padrões:
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Front chama `notificationsService.send(...)` → service dispara `pb.send('/api/notifications/send', ...)` |
+| 2 — Service thin + hook | Email é efeito externo — **sempre** via endpoint custom / hook (`onRecordAfterCreateRequest` ou `routerAdd`) |
+| 3 — Backend é a verdade | Envio acontece no PB, não no front (front não tem acesso SMTP direto) |
+| 4 — Vertical slicing | Templates ficam em `pocketbase/pb_hooks/templates/`; service front em `features/notifications/` |
+| 5 — Type-safety | Templates tipados com interface `MailerPayload` |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/notifications/services/notifications.service.ts
+import pb from '@/shared/services/pocketbase'
+
+export interface MailerPayload {
+  to: string
+  subject: string
+  template: 'welcome' | 'reset-password' | 'invoice' | 'custom'
+  data: Record<string, unknown>
+}
+
+export const notificationsService = {
+  // Padrão 2: envio SEMPRE via hook (Padrão 3 — SMTP nunca no front)
+  async send(payload: MailerPayload) {
+    return pb.send('/api/notifications/send', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  },
+
+  // Casos comuns — wrappers tipados
+  async sendWelcome(email: string, name: string) {
+    return this.send({ to: email, subject: 'Bem-vindo!', template: 'welcome', data: { name } })
+  },
+  async sendPasswordReset(email: string, token: string) {
+    return this.send({ to: email, subject: 'Reset de senha', template: 'reset-password', data: { token } })
+  },
+  async sendInvoice(email: string, invoiceId: string, amount: number) {
+    return this.send({ to: email, subject: 'Nova fatura', template: 'invoice', data: { invoiceId, amount } })
+  },
+}
+```
+
+> ⚠️ **Nunca** exponha credenciais SMTP no front (variáveis `VITE_*` viram strings bundled — visíveis). SMTP fica em env do **processo PB**, lido via `$os.getenv(...)` no hook.
+
 ## Setup SMTP (dev/teste)
 
 `pocketbase/pb_data/.env` (PB lê da env do processo):

--- a/.opencode/skills/domain-feature-scaffold/SKILL.md
+++ b/.opencode/skills/domain-feature-scaffold/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: domain-feature-scaffold
+description: Como bootstrap uma feature nova no template seguindo os 5 padrões da Arquitetura Recomendada — vertical slice (features/<x>/), service layer, collection rules obrigatórias, types do PB, e service thin + hook quando precisar. Use quando o usuário quiser adicionar uma feature end-to-end (ex: 'adicionar feature de eventos', 'criar módulo de inventário') e quiser um workflow consistente desde o schema até a UI.
+---
+
+# Domínio — Feature Scaffold (bootstrap seguindo os 5 padrões)
+
+Esta skill é a **receita** pra adicionar uma feature nova no template **do zero até a UI navegável**, sempre respeitando os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada).
+
+> 📖 Combine com [`evolution-roadmap`](../evolution-roadmap/SKILL.md) pra entender quando usar (Fase 2).
+
+## Inputs da skill
+
+Antes de começar, defina:
+
+```markdown
+## Feature: [nome]
+## Collection(s): [1-3 collections com campos principais]
+## Quem cria / vê / edita: [ex: dono; time; admin]
+## Lógica cross-collection? [sim/não — ex: ao criar X, criar Y também]
+## Integração externa? [ex: Stripe, email, webhook]
+## UI mínima: [1 listagem + 1 form + 1 detalhe]
+```
+
+Se você não consegue responder isso, **volte e entenda o problema**. Esta skill não compensa falta de design.
+
+## Outputs da skill
+
+Estrutura completa criada:
+
+```
+apps/web/src/features/<feature>/
+├── components/
+│   └── <Item>Card.vue          # ex: EventCard.vue
+├── stores/
+│   └── <feature>.store.ts      # consome service
+├── services/
+│   └── <feature>.service.ts    # única camada que fala com pb
+├── composables/
+│   └── use<Feature>Filters.ts  # opcional
+├── views/
+│   ├── <Feature>ListView.vue
+│   └── <Feature>DetailView.vue
+└── index.ts                     # exports públicos
+
+pocketbase/
+├── pb_migrations/
+│   └── <timestamp>_create_<feature>.js
+└── pb_hooks/
+    └── <feature>.pb.js         # hooks custom (se precisar)
+```
+
+## Workflow (7 passos, na ordem)
+
+### Passo 1 — Definir a collection (Padrão 3 + JSVM)
+
+**Não pule isso.** Antes de UI, defina o schema:
+
+```js
+// pocketbase/pb_migrations/1700000000_create_events.js
+/// <reference path="../pb_data/types.d.ts" />
+
+migrate((db) => {
+  Dao(db).saveCollection(new Collection({
+    name: 'events',
+    type: 'base',
+    schema: [
+      { name: 'title', type: 'text', required: true, max: 200 },
+      { name: 'description', type: 'editor' },
+      { name: 'date', type: 'date', required: true },
+      { name: 'location', type: 'text', max: 200 },
+      { name: 'owner', type: 'relation', collectionId: '_pb_users_auth_', maxSelect: 1 },
+      // Padrão JSVM: created/updated DEVEM ser criados manualmente
+      { name: 'created', type: 'autodate', onCreate: true },
+      { name: 'updated', type: 'autodate', onCreate: true, onUpdate: true },
+    ],
+    indexes: [
+      'CREATE INDEX idx_events_date ON events (date)',
+      'CREATE INDEX idx_events_owner ON events (owner)',
+    ],
+    // Padrão 3: rules obrigatórias (SaaS multi-user)
+    listRule:   "owner = @request.auth.id || @request.auth.isAdmin",
+    viewRule:   "owner = @request.auth.id || @request.auth.isAdmin",
+    createRule: "@request.auth.id != ''",
+    updateRule: "owner = @request.auth.id",
+    deleteRule: "owner = @request.auth.id || @request.auth.isAdmin",
+  }))
+}, (db) => Dao(db).deleteCollection('events'))
+```
+
+**Checklist de migração (Padrão 3)**:
+- [ ] Todos os 5 rules definidos (não `null`)
+- [ ] `created` + `updated` adicionados manualmente (JSVM não auto-cria)
+- [ ] Índices SQL nos campos que vão ser filtrados/ordenados
+- [ ] `owner` (ou similar) presente se for SaaS multi-user
+
+### Passo 2 — Rodar dev pra gerar types (Padrão 5)
+
+```bash
+# Em terminal separado, deixar rodando
+npm run dev:pb
+```
+
+Depois de 1-2s, `pocketbase/pb_data/types.d.ts` é regenerado com `EventsRecord`. Confirme que existe.
+
+**Configure o alias `@pb-types` uma vez** (se ainda não configurou):
+
+```json
+// apps/web/tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@pb-types/*": ["../../pocketbase/pb_data/types.d.ts"]
+    }
+  }
+}
+```
+
+### Passo 3 — Criar o service (Padrão 1 + 2)
+
+```ts
+// apps/web/src/features/events/services/events.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { EventsRecord } from '@pb-types'
+
+export const eventsService = {
+  // CRUD — Padrão 1 (thin wrapper)
+  async list(page = 1, perPage = 50) {
+    return pb.collection('events').getList<EventsRecord>(page, perPage, {
+      sort: 'date',
+    })
+  },
+  async getById(id: string) {
+    return pb.collection('events').getOne<EventsRecord>(id)
+  },
+  async create(data: Partial<EventsRecord>) {
+    return pb.collection('events').create<EventsRecord>(data)
+  },
+  async update(id: string, data: Partial<EventsRecord>) {
+    return pb.collection('events').update<EventsRecord>(id, data)
+  },
+  async delete(id: string) {
+    return pb.collection('events').delete(id)
+  },
+
+  // Lógica avançada — Padrão 2 (só se precisar)
+  // Ex: ao cancelar evento, notificar participants via hook custom
+  async cancel(id: string) {
+    return pb.send(`/api/events/${id}/cancel`, { method: 'POST' })
+  },
+}
+```
+
+**Onde mora o service**:
+- `apps/web/src/features/events/services/events.service.ts` se for feature nova
+- `apps/web/src/shared/services/files.service.ts` se for utilitário compartilhado
+
+### Passo 4 — Criar o store (Padrão 1 + 5)
+
+```ts
+// apps/web/src/features/events/stores/events.store.ts
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { eventsService } from '../services/events.service'
+import type { EventsRecord } from '@pb-types'
+
+export const useEventsStore = defineStore('events', () => {
+  // ---- state
+  const items = ref<EventsRecord[]>([])
+  const current = ref<EventsRecord | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // ---- getters
+  const upcoming = computed(() => {
+    const now = new Date().toISOString()
+    return items.value.filter(e => e.date >= now)
+  })
+
+  // ---- actions — SEMPRE via service
+  async function fetchAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await eventsService.list()
+      items.value = res.items
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao buscar eventos'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchById(id: string) {
+    current.value = await eventsService.getById(id)
+  }
+
+  async function create(data: Partial<EventsRecord>) {
+    const created = await eventsService.create(data)
+    items.value.push(created)
+    return created
+  }
+
+  async function update(id: string, data: Partial<EventsRecord>) {
+    const updated = await eventsService.update(id, data)
+    const i = items.value.findIndex(e => e.id === id)
+    if (i >= 0) items.value[i] = updated
+    if (current.value?.id === id) current.value = updated
+    return updated
+  }
+
+  async function remove(id: string) {
+    await eventsService.delete(id)
+    items.value = items.value.filter(e => e.id !== id)
+    if (current.value?.id === id) current.value = null
+  }
+
+  return { items, current, loading, error, upcoming, fetchAll, fetchById, create, update, remove }
+})
+```
+
+### Passo 5 — Views (componentes Vue)
+
+#### List view
+
+```vue
+<!-- apps/web/src/features/events/views/EventsListView.vue -->
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useEventsStore } from '../stores/events.store'
+import EventCard from '../components/EventCard.vue'
+
+const events = useEventsStore()
+const search = ref('')
+
+onMounted(() => events.fetchAll())
+
+const filtered = computed(() => {
+  const q = search.value.toLowerCase().trim()
+  if (!q) return events.items
+  return events.items.filter(e =>
+    e.title.toLowerCase().includes(q) ||
+    e.location?.toLowerCase().includes(q)
+  )
+})
+</script>
+
+<template>
+  <div class="p-6 max-w-6xl mx-auto">
+    <header class="flex justify-between items-center mb-6">
+      <h1 class="text-3xl font-bold">Eventos</h1>
+      <router-link to="/events/new"
+        class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+        Novo evento
+      </router-link>
+    </header>
+
+    <input v-model="search" placeholder="Buscar..."
+      class="w-full mb-6 px-4 py-2 border rounded-lg" />
+
+    <div v-if="events.loading" class="text-center py-12 text-gray-500">
+      Carregando...
+    </div>
+    <div v-else-if="filtered.length === 0" class="text-center py-12 text-gray-500">
+      Nenhum evento encontrado.
+    </div>
+    <div v-else class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <EventCard v-for="e in filtered" :key="e.id" :event="e" />
+    </div>
+  </div>
+</template>
+```
+
+#### Card component
+
+```vue
+<!-- apps/web/src/features/events/components/EventCard.vue -->
+<script setup lang="ts">
+import type { EventsRecord } from '@pb-types'
+
+defineProps<{ event: EventsRecord }>()
+</script>
+
+<template>
+  <router-link :to="`/events/${event.id}`"
+    class="block bg-white rounded-2xl shadow p-5 hover:shadow-lg transition">
+    <h2 class="text-xl font-bold mb-2">{{ event.title }}</h2>
+    <p class="text-sm text-gray-500 mb-1">
+      📅 {{ new Date(event.date).toLocaleDateString('pt-BR') }}
+    </p>
+    <p v-if="event.location" class="text-sm text-gray-500">
+      📍 {{ event.location }}
+    </p>
+  </router-link>
+</template>
+```
+
+### Passo 6 — Adicionar rotas (auth guard já configurado)
+
+```ts
+// apps/web/src/router/index.ts (adicionar dentro do array routes)
+{
+  path: '/events',
+  name: 'events',
+  component: () => import('@/features/events/views/EventsListView.vue'),
+  meta: { requiresAuth: true },
+},
+{
+  path: '/events/new',
+  name: 'events-new',
+  component: () => import('@/features/events/views/EventFormView.vue'),
+  meta: { requiresAuth: true },
+},
+{
+  path: '/events/:id',
+  name: 'event-detail',
+  component: () => import('@/features/events/views/EventDetailView.vue'),
+  meta: { requiresAuth: true },
+  props: true,
+},
+```
+
+> ⚠️ Path **sem** `/app/` — o `base: '/app/'` do Vite Router cuida.
+
+### Passo 7 — Hook custom (só se Padrão 2 precisar)
+
+Se a feature tem **lógica cross-collection ou efeito externo** (ex: ao cancelar evento, notificar participants), criar hook no PB:
+
+```js
+// pocketbase/pb_hooks/events.pb.js
+/// <reference path="../pb_data/types.d.ts" />
+
+routerAdd('POST', '/api/events/:id/cancel', async (e) => {
+  const id = e.requestInfo().pathParams.id
+  const event = $app.findRecordById('events', id)
+  if (!event) return e.json(404, { error: 'not found' })
+  if (event.getString('owner') !== e.auth?.id && !e.auth?.isAdmin) {
+    return e.json(403, { error: 'forbidden' })
+  }
+
+  event.set('status', 'cancelled')
+  $app.save(event)
+
+  // Efeito externo: notificar participants
+  // (exemplo com collection 'participants' relacionada)
+  const participants = $app.findRecordsByFilter('participants', `event = "${id}"`)
+  for (const p of participants) {
+    // enviar email, etc.
+  }
+
+  return e.json(200, { ok: true })
+}, $apis.requireAuth())
+```
+
+E no service (passo 3), o `cancel` já chama esse endpoint.
+
+## `index.ts` da feature (controla o que vaza)
+
+```ts
+// apps/web/src/features/events/index.ts
+
+// Páginas (vazam pro router)
+export { default as EventsListView } from './views/EventsListView.vue'
+export { default as EventDetailView } from './views/EventDetailView.vue'
+export { default as EventFormView } from './views/EventFormView.vue'
+
+// Store (vaza pra componentes que precisam)
+export { useEventsStore } from './stores/events.store'
+
+// NÃO exportar service, components internos, composables
+// (mantém fronteira clara — outras features consomem só o que está aqui)
+```
+
+## Critérios de pronto
+
+A feature está pronta quando:
+
+- [ ] Migration commitada no git, com collection rules definidos
+- [ ] Types regenerados (`@pb-types` aponta pra `EventsRecord`)
+- [ ] Service criado em `features/<x>/services/`
+- [ ] Store consome service, não `pb` direto
+- [ ] View lista + view detalhe + view form funcionais
+- [ ] Rota adicionada com `meta.requiresAuth` se precisar
+- [ ] Try/catch em toda action async (sem `any`)
+- [ ] Se tem lógica cross-collection: hook custom + endpoint
+- [ ] Testado: tentar burlar via curl retorna 401/403/404 (collection rules OK)
+- [ ] Testado: criar/editar/deletar pela UI funciona end-to-end
+- [ ] `index.ts` da feature controla o que vaza
+
+## Checklist anti-pattern (debug rápido)
+
+Antes de commitar a feature nova, conferir:
+
+- [ ] Nenhum `pb.collection()` em store ou componente (só no service)
+- [ ] Nenhum `any` em type de store/service
+- [ ] Nenhuma collection com rules `null`
+- [ ] Nenhum `created`/`updated` faltando em migration
+- [ ] Nenhum `require('fs')` em hook (JSVM não suporta)
+- [ ] Nenhum segredo em `.env.local` commitado
+- [ ] Nenhum `process.env.VITE_*` em componente (Vite usa `import.meta.env`)
+- [ ] Store não chama `authRefresh()` (responsabilidade do router)
+
+## Combinar com outras skills
+
+Esta skill é o **workflow**. As outras skills dão o conteúdo específico:
+
+| Quando... | Use... |
+|---|---|
+| Feature tem upload de arquivos | [`domain-storage-files`](../domain-storage-files/SKILL.md) |
+| Feature tem realtime (multi-user live) | [`domain-realtime`](../domain-realtime/SKILL.md) |
+| Feature envia emails transacionais | [`domain-email-hooks`](../domain-email-hooks/SKILL.md) |
+| Feature tem múltiplos roles (admin/editor) | [`domain-rbac`](../domain-rbac/SKILL.md) |
+| Feature cobra (planos/Stripe) | [`domain-saas-billing`](../domain-saas-billing/SKILL.md) |
+| Dúvida de estrutura de pasta | [`vue-pinia-store`](../vue-pinia-store/SKILL.md) — Padrão 1, 4, 5 |
+| Dúvida de collection rules | [`pocketbase-collections`](../pocketbase-collections/SKILL.md) — Padrão 3 |
+| Dúvida de "faz no front ou no PB?" | [`evolution-roadmap`](../evolution-roadmap/SKILL.md) + o framework de 3 perguntas |
+
+## Exemplo end-to-end
+
+Referência: [`domain-crm-leads`](../domain-crm-leads/SKILL.md) é o resultado de rodar esta skill pra uma feature de CRM (leads + contacts + activities).

--- a/.opencode/skills/domain-landing-pages/SKILL.md
+++ b/.opencode/skills/domain-landing-pages/SKILL.md
@@ -9,6 +9,43 @@ Você vai pegar esse template e criar **um app por cliente**. Cada cliente vai p
 
 > Foco: entregar rápido pro cliente. Não tem otimização de SEO agressiva (não é WordPress). Cada landing é um **experimento de copy + design**, não um poste de blog.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+A landing segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada), com adaptação (é mais simples que o web app):
+
+| Padrão | Aplicação na landing |
+|---|---|
+| 1 — Camada de Service | Form de contato / lead captura consome `leadsService` (não `pb.collection()` direto) |
+| 2 — Service thin + hook | Form simples via service; "agendar demo" / "solicitar proposta" com lógica multi-step via hook custom |
+| 3 — Backend é a verdade | Collection `leads` com rules (público pode criar, admin-only list/view/update) |
+| 4 — Vertical slicing | Landing é vertical por segmento: `landing/<segmento>/{components,forms}/` |
+| 5 — Type-safety | Tipos via `@pb-types`; `LeadsRecord` tipado |
+
+### Service layer desta skill
+
+```ts
+// apps/landing/src/services/leads.service.ts
+import pb from '@/services/pocketbase'
+import type { LeadsRecord } from '@pb-types'
+
+export const leadsService = {
+  // Padrão 1 + 2: CRUD simples, encapsulado
+  async capture(data: Partial<LeadsRecord>) {
+    return pb.collection('leads').create<LeadsRecord>(data)
+  },
+
+  // Padrão 2: agendamento / solicitação multi-step vai via hook
+  async scheduleDemo(data: { email: string; company: string; segment: string }) {
+    return pb.send('/api/leads/schedule-demo', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    })
+  },
+}
+```
+
+> 💡 **Diferença da landing pro web app**: a landing é mais simples, geralmente 1-2 services. Não precisa de vertical slicing agressivo — fica em `apps/landing/src/`. Padrão 4 aplica quando a landing tem múltiplos segmentos/idiomas.
+
 ## Filosofia
 
 | Decisão | Escolha |

--- a/.opencode/skills/domain-rbac/SKILL.md
+++ b/.opencode/skills/domain-rbac/SKILL.md
@@ -253,36 +253,70 @@ router.beforeEach((to, _from, next) => {
 }
 ```
 
-## 5. Pinia store admin de users
+## 5. Pinia store admin de users (via service layer — Padrão 1)
+
+### Service
 
 ```ts
-// stores/admin-users.ts
+// apps/web/src/features/rbac/services/admin-users.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { UsersRecord } from '@pb-types'
+import type { Role } from '../composables/usePermissions'
+
+export const adminUsersService = {
+  async list(page = 1, perPage = 200) {
+    return pb.collection('users').getList<UsersRecord>(page, perPage, {
+      sort: 'email', fields: 'id,email,name,role,team,status',
+    })
+  },
+  async updateRole(id: string, role: Role) {
+    return pb.collection('users').update<UsersRecord>(id, { role })
+  },
+  async delete(id: string) {
+    return pb.collection('users').delete(id)
+  },
+}
+```
+
+### Store
+
+```ts
+// apps/web/src/features/rbac/stores/admin-users.store.ts
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import pb from '@/services/pocketbase'
+import { adminUsersService } from '../services/admin-users.service'
+import { type Role } from '../composables/usePermissions'
+import type { UsersRecord } from '@pb-types'
 
 export const useAdminUsersStore = defineStore('admin-users', () => {
-  const items = ref<any[]>([])
+  const items = ref<UsersRecord[]>([])
   const loading = ref(false)
+  const error = ref<string | null>(null)
 
   async function fetchAll() {
     loading.value = true
+    error.value = null
     try {
-      items.value = (await pb.collection('users').getList(1, 200, { sort: 'email' })).items
-    } finally { loading.value = false }
+      const res = await adminUsersService.list()
+      items.value = res.items
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao listar usuários'
+    } finally {
+      loading.value = false
+    }
   }
 
-  async function changeRole(id: string, role: string) {
-    await pb.collection('users').update(id, { role })
+  async function changeRole(id: string, role: Role) {
+    await adminUsersService.updateRole(id, role)
     await fetchAll()
   }
 
   async function remove(id: string) {
-    await pb.collection('users').delete(id)
+    await adminUsersService.delete(id)
     items.value = items.value.filter(u => u.id !== id)
   }
 
-  return { items, loading, fetchAll, changeRole, remove }
+  return { items, loading, error, fetchAll, changeRole, remove }
 })
 ```
 

--- a/.opencode/skills/domain-rbac/SKILL.md
+++ b/.opencode/skills/domain-rbac/SKILL.md
@@ -7,6 +7,56 @@ description: Como implementar RBAC (Role-Based Access Control) granular no templ
 
 PocketBase não tem RBAC pronto. Mas o template já tem `auth.ts` que suporta `user.role`. Esta skill monta o sistema inteiro.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Lógica de permissão fica no service + composable; store consome service |
+| 2 — Service thin + hook | CRUD de roles via service; checagens server-side via hook `onRecordBeforeCreateRequest` |
+| 3 — Backend é a verdade | Backend bloqueia criação de admin via hook; front só **esconde UI** por UX |
+| 4 — Vertical slicing | Estrutura `features/rbac/{permissions,middleware,directives}/` |
+| 5 — Type-safety | Role/Ação como union types, não strings soltas |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/rbac/services/permissions.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { UsersRecord } from '@pb-types'
+import { usePermissions } from '../composables/usePermissions'
+
+export const permissionsService = {
+  // CRUD — Padrão 1 + 2
+  async listUsersWithRoles(page = 1, perPage = 200) {
+    return pb.collection('users').getList<UsersRecord>(page, perPage, {
+      sort: '-created', fields: 'id,email,name,role,team,status',
+    })
+  },
+  async updateUserRole(userId: string, role: UsersRecord['role']) {
+    return pb.collection('users').update<UsersRecord>(userId, { role })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoint custom)
+  async listUsersByPermission(permission: string) {
+    return pb.send('/api/admin/users/by-permission', {
+      method: 'POST',
+      body: JSON.stringify({ permission }),
+    })
+  },
+}
+
+// Helper de checagem (client-side, NÃO substitui backend)
+export const can = (user: UsersRecord | null, action: string, resource: string) => {
+  if (!user) return false
+  const perms = usePermissions(user.role as any)
+  return perms.can(action, resource)
+}
+```
+
+> ⚠️ **Lembrete crítico**: gating no front é **UX, não segurança**. O backend (Padrão 3) enforça via collection rules + hooks. Esta skill fornece a matriz pro front decidir o que mostrar; o PB decide o que aceitar.
+
 ## Modelo
 
 ```

--- a/.opencode/skills/domain-realtime/SKILL.md
+++ b/.opencode/skills/domain-realtime/SKILL.md
@@ -7,6 +7,46 @@ description: Como usar PocketBase subscriptions pra construir features em tempo 
 
 PocketBase tem **subscriptions SSE** nativas. Cada client abre um stream e recebe `create/update/delete` em tempo real. Perfeito pra kanban multi-user, chat, presença, dashboards live.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Subscribe via service helper (não chama `pb.collection().subscribe()` direto na store) |
+| 2 — Service thin + hook | Subscriptions são CRUD-level (vão no service); presença/typing vão via hook custom |
+| 3 — Backend é a verdade | Collection rules continuam aplicando — subscription só entrega o que o user pode ver |
+| 4 — Vertical slicing | Realtime é transversal; o subscribe vive dentro do service de cada feature |
+| 5 — Type-safety | Subscribe tipado com `<XxxRecord>` |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/<feature>/services/<feature>.realtime.ts
+import pb from '@/shared/services/pocketbase'
+import type { CardsRecord } from '@pb-types'
+
+export const cardsRealtime = {
+  // Padrão 1: subscribe encapsulado no service (não na store)
+  subscribe(handler: (e: { action: string; record: CardsRecord }) => void) {
+    return pb.collection('cards').subscribe<CardsRecord>('*', handler)
+  },
+
+  // Padrão 2: presença/typing via endpoint custom
+  async announcePresence(roomId: string) {
+    return pb.send('/api/realtime/presence', {
+      method: 'POST',
+      body: JSON.stringify({ room: roomId }),
+    })
+  },
+  async getOnlineUsers(roomId: string) {
+    return pb.send(`/api/realtime/presence/${roomId}`)
+  },
+}
+```
+
+> 📖 Esta skill complementa `vue-pinia-store` (cleanup de subscriptions via `onUnmounted`).
+
 ## Conceito
 
 ```ts

--- a/.opencode/skills/domain-realtime/SKILL.md
+++ b/.opencode/skills/domain-realtime/SKILL.md
@@ -62,42 +62,68 @@ unsub()
 
 > ⚠️ **Sempre** guardar `unsub()` e chamar no `onUnmounted` da store/componente. Esquecer disso vaza conexão.
 
-## Patterns Pinia
+## Patterns Pinia (via service layer — Padrão 1)
 
-### Store com subscription auto-cleanup
+### Service (encapsula subscribe + cleanup)
 
 ```ts
-// stores/realtime.ts (helper genérico)
-import { onUnmounted } from 'vue'
-import pb from '@/services/pocketbase'
+// apps/web/src/shared/services/realtime.service.ts
+import pb from '@/shared/services/pocketbase'
 
-export function useRealtimeSubscription(collection: string, handler: (e: any) => void) {
-  const unsub = pb.collection(collection).subscribe('*', handler)
-  onUnmounted(() => { try { unsub() } catch {} })
+export interface RealtimeEvent<T> {
+  action: 'create' | 'update' | 'delete'
+  record: T
+}
+
+export const realtimeService = {
+  // Helper genérico tipado (Padrão 5)
+  subscribe<T>(collection: string, handler: (e: RealtimeEvent<T>) => void): () => void {
+    return pb.collection(collection).subscribe<T>('*', handler as (e: unknown) => void)
+  },
+
+  // Lógica avançada (Padrão 2) — presença/typing via hook custom
+  async announcePresence(roomId: string) {
+    return pb.send('/api/realtime/presence', {
+      method: 'POST',
+      body: JSON.stringify({ room: roomId }),
+    })
+  },
+  async getOnlineUsers(roomId: string) {
+    return pb.send(`/api/realtime/presence/${roomId}`)
+  },
 }
 ```
 
-Uso em qualquer store:
+### Store (consome service, cleanup via `onUnmounted`)
 
 ```ts
-// stores/kanban.ts
+// apps/web/src/features/kanban/stores/kanban.store.ts
 import { defineStore } from 'pinia'
 import { ref, onUnmounted } from 'vue'
-import pb from '@/services/pocketbase'
+import { cardsService } from '../services/cards.service'
+import { realtimeService } from '@/shared/services/realtime.service'
+import type { CardsRecord } from '@pb-types'
 
 export const useKanbanStore = defineStore('kanban', () => {
-  const cards = ref<any[]>([])
+  const cards = ref<CardsRecord[]>([])
+  const loading = ref(false)
   let unsub: (() => void) | null = null
 
   async function load() {
-    cards.value = (await pb.collection('cards').getList(1, 200)).items
+    loading.value = true
+    try {
+      cards.value = await cardsService.listAll()
+    } finally {
+      loading.value = false
+    }
   }
 
   function subscribe() {
     if (unsub) return
-    unsub = pb.collection('cards').subscribe('*', (e) => {
-      if (e.action === 'create') cards.value.push(e.record)
-      else if (e.action === 'update') {
+    unsub = realtimeService.subscribe<CardsRecord>('cards', (e) => {
+      if (e.action === 'create') {
+        cards.value.push(e.record)
+      } else if (e.action === 'update') {
         const i = cards.value.findIndex(c => c.id === e.record.id)
         if (i >= 0) cards.value[i] = e.record
       } else if (e.action === 'delete') {
@@ -113,15 +139,17 @@ export const useKanbanStore = defineStore('kanban', () => {
   // cleanup automático se store for desmontado
   onUnmounted(() => unsubscribe())
 
-  return { cards, load, subscribe, unsubscribe }
+  return { cards, loading, load, subscribe, unsubscribe }
 })
 ```
+
+> O service de cards (`cardsService.listAll()`) vive em `features/<feature>/services/cards.service.ts` — CRUD básico via `pb.collection()`. A subscribe fica no `realtimeService` compartilhado.
 
 No view:
 
 ```vue
 <script setup lang="ts">
-import { useKanbanStore } from '@/stores/kanban'
+import { useKanbanStore } from '@/features/kanban/stores/kanban.store'
 import { onMounted } from 'vue'
 
 const kb = useKanbanStore()

--- a/.opencode/skills/domain-saas-billing/SKILL.md
+++ b/.opencode/skills/domain-saas-billing/SKILL.md
@@ -326,59 +326,127 @@ routerAdd('POST', '/api/billing/portal', async (c) => {
 })
 ```
 
-## 3. Entitlements — gating de features
+## 3. Entitlements — gating de features (via service layer — Padrão 1)
 
-### `apps/web/src/composables/useEntitlements.ts`
+### Service
 
 ```ts
-import { computed } from 'vue'
-import { useAuthStore } from '@/stores/auth'
-import pb from '@/services/pocketbase'
+// apps/web/src/features/billing/services/billing.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PlansRecord, SubscriptionsRecord, InvoicesRecord } from '@pb-types'
 
-export interface Entitlements {
-  plan: string | null
-  features: Set<string>
-  limits: Record<string, number>
-  isPro: boolean
-  can: (feature: string) => boolean
-  limitReached: (key: string, current: number) => boolean
+export const billingService = {
+  // CRUD — Padrão 1 + 2
+  async listActivePlans() {
+    return pb.collection('plans').getFullList<PlansRecord>({
+      filter: 'is_active = true', sort: 'sort_order',
+    })
+  },
+  async getCurrentSubscription(userId: string) {
+    return pb.collection('subscriptions').getFirstListItem<SubscriptionsRecord>(
+      `user = "${userId}"`,
+      { sort: '-created', expand: 'plan' },
+    )
+  },
+  async listInvoices(userId: string, page = 1) {
+    return pb.collection('invoices').getList<InvoicesRecord>(page, 20, {
+      filter: `user = "${userId}"`, sort: '-created',
+    })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoints custom protegidos)
+  async createCheckoutSession(priceId: string, planSlug: string) {
+    return pb.send('/api/billing/checkout', {
+      method: 'POST',
+      body: JSON.stringify({ priceId, planSlug }),
+    }) as Promise<{ url: string }>
+  },
+  async cancelSubscription() {
+    return pb.send('/api/billing/cancel', { method: 'POST' })
+  },
+  async reactivateSubscription() {
+    return pb.send('/api/billing/reactivate', { method: 'POST' })
+  },
+  async getEntitlements() {
+    return pb.send('/api/billing/entitlements') as Promise<{
+      plan: string
+      features: string[]
+      limits: Record<string, number>
+    }>
+  },
 }
+```
 
-export function useEntitlements(): Entitlements {
+### Store de entitlements
+
+```ts
+// apps/web/src/features/billing/stores/entitlements.store.ts
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { billingService } from '../services/billing.service'
+import { useAuthStore } from '@/stores/auth'
+
+export const useEntitlementsStore = defineStore('entitlements', () => {
   const auth = useAuthStore()
+  const sub = ref<Awaited<ReturnType<typeof billingService.getCurrentSubscription>> | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
 
-  // cache simples — pode usar Pinia store
-  const sub = ref<any>(null)
-  onMounted(async () => {
+  const features = computed(() => new Set((sub.value as any)?.expand?.plan?.features ?? []))
+  const limits   = computed(() => (sub.value as any)?.expand?.plan?.limits ?? {})
+  const plan     = computed(() => (sub.value as any)?.expand?.plan?.slug ?? null)
+  const isPro    = computed(() => features.value.has('pro') || features.value.has('enterprise'))
+
+  async function load() {
     if (!auth.user) return
+    loading.value = true
+    error.value = null
     try {
-      sub.value = await pb.collection('subscriptions').getFirstListItem(`user = "${auth.user.id}"`)
-    } catch { /* sem subscription = free tier */ }
-  })
+      sub.value = await billingService.getCurrentSubscription(auth.user.id)
+    } catch {
+      // sem subscription = free tier (não é erro)
+      sub.value = null
+    } finally {
+      loading.value = false
+    }
+  }
 
-  const features = computed(() => new Set(sub.value?.expand?.plan?.features ?? []))
-  const limits   = computed(() => sub.value?.expand?.plan?.limits ?? {})
+  function can(feature: string) { return features.value.has(feature) }
+  function limitReached(key: string, current: number) {
+    const limit = limits.value[key]
+    return typeof limit === 'number' && limit !== -1 && current >= limit
+  }
 
+  return { sub, loading, error, plan, features, limits, isPro, load, can, limitReached }
+})
+```
+
+### Uso num componente (via composable que consome a store)
+
+```ts
+// apps/web/src/features/billing/composables/useEntitlements.ts
+import { useEntitlementsStore } from '../stores/entitlements.store'
+
+export function useEntitlements() {
+  const store = useEntitlementsStore()
   return {
-    plan: sub.value?.expand?.plan?.slug ?? null,
-    features: features.value,
-    limits:   limits.value,
-    isPro: features.value.has('pro') || features.value.has('enterprise'),
-    can:     (f: string) => features.value.has(f),
-    limitReached: (k: string, current: number) => {
-      const limit = limits.value[k]
-      return typeof limit === 'number' && limit !== -1 && current >= limit
-    },
+    plan: store.plan,
+    features: store.features,
+    limits: store.limits,
+    isPro: store.isPro,
+    can: store.can,
+    limitReached: store.limitReached,
+    load: store.load,
   }
 }
 ```
 
-### Uso num componente
-
 ```vue
 <script setup lang="ts">
-import { useEntitlements } from '@/composables/useEntitlements'
+import { onMounted } from 'vue'
+import { useEntitlements } from '@/features/billing/composables/useEntitlements'
 const ent = useEntitlements()
+onMounted(() => ent.load())
 </script>
 
 <template>
@@ -394,35 +462,32 @@ const ent = useEntitlements()
 
 ## 4. UI de planos
 
-`apps/web/src/views/billing/PricingView.vue`:
+`apps/web/src/features/billing/views/PricingView.vue` (consome o service):
 
 ```vue
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
-import pb from '@/services/pocketbase'
+import { useRouter } from 'vue-router'
+import { billingService } from '../services/billing.service'
 import { useAuthStore } from '@/stores/auth'
+import type { PlansRecord } from '@pb-types'
 
-const plans = ref<any[]>([])
+const plans = ref<PlansRecord[]>([])
 const billing = ref<'monthly' | 'yearly'>('monthly')
 const auth = useAuthStore()
+const router = useRouter()
 
 onMounted(async () => {
-  const res = await pb.collection('plans').getList(1, 50, {
-    filter: 'is_active = true', sort: 'sort_order',
-  })
-  plans.value = res.items
+  plans.value = await billingService.listActivePlans()
 })
 
-async function subscribe(plan: any) {
-  if (!auth.isLoggedIn) { auth.$router?.push('/app/login'); return }
+async function subscribe(plan: PlansRecord) {
+  if (!auth.isLoggedIn) { router.push('/app/login'); return }
   const priceId = billing.value === 'monthly'
     ? plan.stripe_monthly_price_id
     : plan.stripe_yearly_price_id
 
-  const { url } = await pb.send('/api/billing/checkout', {
-    method: 'POST',
-    body: JSON.stringify({ priceId, planSlug: plan.slug }),
-  })
+  const { url } = await billingService.createCheckoutSession(priceId, plan.slug)
   window.location.href = url
 }
 </script>

--- a/.opencode/skills/domain-saas-billing/SKILL.md
+++ b/.opencode/skills/domain-saas-billing/SKILL.md
@@ -9,6 +9,63 @@ Caso real: app freemium/SaaS com planos Free/Pro/Enterprise, gating de features,
 
 > **Stack típico**: Stripe Checkout (cliente) + Stripe Webhook (PB hook) + collection `subscriptions` (sincronizada via webhook).
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Store de `subscriptions` consome `billingService`, nunca `pb` direto |
+| 2 — Service thin + hook | CRUD direto; checkout/webhook/refund via endpoints custom (hooks PB) |
+| 3 — Backend é a verdade | Webhook valida assinatura Stripe no backend; entitlements via collection rules |
+| 4 — Vertical slicing | Estrutura `features/billing/{plans,subscriptions,invoices,entitlements}/` |
+| 5 — Type-safety | Tipos via `@pb-types`; `Plan`, `Subscription`, `Entitlement` como tipos do PB |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/features/billing/services/billing.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PlansRecord, SubscriptionsRecord, InvoicesRecord } from '@pb-types'
+
+export const billingService = {
+  // CRUD — Padrão 1 + 2
+  async listPlans() {
+    return pb.collection('plans').getFullList<PlansRecord>({ filter: 'is_active = true', sort: 'sort_order' })
+  },
+  async getCurrentSubscription(userId: string) {
+    return pb.collection('subscriptions').getFirstListItem<SubscriptionsRecord>(
+      `user = "${userId}"`,
+      { sort: '-created' }
+    )
+  },
+  async listInvoices(userId: string, page = 1) {
+    return pb.collection('invoices').getList<InvoicesRecord>(page, 20, {
+      filter: `user = "${userId}"`, sort: '-created',
+    })
+  },
+
+  // Lógica avançada — Padrão 2 (endpoints custom protegidos)
+  async createCheckoutSession(planSlug: string) {
+    return pb.send('/api/billing/checkout', {
+      method: 'POST',
+      body: JSON.stringify({ plan: planSlug }),
+    })
+  },
+  async cancelSubscription() {
+    return pb.send('/api/billing/cancel', { method: 'POST' })
+  },
+  async reactivateSubscription() {
+    return pb.send('/api/billing/reactivate', { method: 'POST' })
+  },
+  async getEntitlements() {
+    return pb.send('/api/billing/entitlements')
+  },
+}
+```
+
+> ⚠️ **Webhook do Stripe** roda **no backend (Padrão 3)**. Validar assinatura antes de mexer em `subscriptions`/`entitlements`. Detalhes na seção "Hook Stripe" abaixo.
+
 ## Visão do domínio
 
 ```

--- a/.opencode/skills/domain-storage-files/SKILL.md
+++ b/.opencode/skills/domain-storage-files/SKILL.md
@@ -122,10 +122,9 @@ async function upload() {
   if (!file.value) return
   loading.value = true
   try {
-    const fd = new FormData()
-    fd.append('avatar', file.value)
-    const updated = await pb.collection('users').update(props.userId, fd)
-    auth.user = updated          // atualiza store reativamente
+    // Padrão 1: consome service, não pb direto
+    const updated = await userFilesService.uploadAvatar(props.userId, file.value)
+    auth.user = updated
     emit('updated', updated.avatar)
     preview.value = null
   } finally {
@@ -135,7 +134,7 @@ async function upload() {
 
 const currentUrl = () => {
   if (preview.value) return preview.value
-  if (props.avatar) return pb.files.getURL({ id: props.userId, collectionId: '_pb_users_auth_' }, props.avatar, { thumb: '100x100' })
+  if (props.avatar) return userFilesService.getAvatarUrl(props.userId, props.avatar)
   return null
 }
 </script>
@@ -181,22 +180,35 @@ $app.dao().saveCollection(leadsCol)
 ### Upload múltiplo
 
 ```ts
-async function uploadAttachments(recordId: string, files: File[]) {
-  const fd = new FormData()
-  for (const f of files) fd.append('attachments', f)
-  return pb.collection('leads').update(recordId, fd)
+// apps/web/src/features/crm/leads/services/leads-files.service.ts
+import { filesService } from '@/shared/services/files.service'
+import type { LeadsRecord } from '@pb-types'
+
+export const leadFilesService = {
+  // Padrão 1: helper específico da feature, consome filesService compartilhado
+  async uploadAttachments(recordId: string, files: File[]) {
+    const fd = new FormData()
+    for (const f of files) fd.append('attachments', f)
+    return filesService.uploadToRecord<LeadsRecord>('leads', recordId, 'attachments', fd)
+  },
 }
 ```
 
-### Visualizar/baixar
+Uso:
+
+```ts
+await leadFilesService.uploadAttachments(leadId, [file1, file2])
+```
+
+### Visualizar/baixar (componente consome service)
 
 ```vue
 <script setup lang="ts">
-import pb from '@/services/pocketbase'
+import { filesService } from '@/shared/services/files.service'
 const props = defineProps<{ record: any; field: string }>()
 
 function url(file: string, thumb?: string) {
-  return pb.files.getURL(props.record, file, { thumb })
+  return filesService.getUrl(props.record, file)
 }
 </script>
 
@@ -225,11 +237,13 @@ col.schema.findFieldByName('file').options = { ...col.schema.findFieldByName('fi
 $app.dao().saveCollection(col)
 ```
 
-Acessar de client autenticado:
+Acessar de client autenticado (via service):
 
 ```ts
-const token = pb.authStore.token
-const url = pb.files.getURL(record, record.file) + `?token=${token}`
+// Padrão 1: consome o service de signed URL
+import { filesService } from '@/shared/services/files.service'
+
+const url = await filesService.getSignedUrl('documents', recordId, record.file)
 ```
 
 Pra URL temporária (assinada server-side):

--- a/.opencode/skills/domain-storage-files/SKILL.md
+++ b/.opencode/skills/domain-storage-files/SKILL.md
@@ -7,6 +7,71 @@ description: Como implementar upload e gerenciamento de arquivos no template —
 
 PocketBase tem campo `file` nativo (filesystem local) + S3-compatível opcional. Cobre 90% dos casos sem libs externas.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill segue os 5 padrões da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 1 — Camada de Service | Upload/download/delete via service (`filesService`), não `pb.collection().upload()` direto na store |
+| 2 — Service thin + hook | Upload de arquivo simples via service; signed URLs pra arquivos privados via hook custom |
+| 3 — Backend é a verdade | Regras de acesso ao arquivo (`listRule`/`viewRule`) são collection rules; validação de MIME/tamanho via schema |
+| 4 — Vertical slicing | `features/<feature>/` consome `filesService` compartilhado em `shared/` |
+| 5 — Type-safety | Tipos via `@pb-types`; records com campo `file` são tipados |
+
+### Service layer desta skill
+
+```ts
+// apps/web/src/shared/services/files.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { UsersRecord, PostsRecord } from '@pb-types'
+
+export const filesService = {
+  // Upload (Padrão 1 + 2) — wrapper genérico
+  async uploadToRecord<T extends Record<string, any>>(
+    collection: string,
+    recordId: string,
+    field: string,
+    file: File,
+  ): Promise<T> {
+    const formData = new FormData()
+    formData.append(field, file)
+    return pb.collection(collection).update<T>(recordId, formData)
+  },
+
+  // URL pública (Padrão 1) — passa pelo SDK do PB
+  getUrl(record: UsersRecord | PostsRecord, filename: string): string {
+    return pb.files.getURL(record, filename)
+  },
+
+  // Signed URL para arquivos privados — Padrão 2 (hook custom)
+  async getSignedUrl(collection: string, recordId: string, filename: string): Promise<string> {
+    const { token } = await pb.send('/api/files/signed-token', {
+      method: 'POST',
+      body: JSON.stringify({ collection, recordId, filename }),
+    })
+    return `${pb.baseUrl}/api/files/${collection}/${recordId}/${filename}?token=${token}`
+  },
+
+  // Thumbnail on-the-fly (Padrão 2 — gerado no hook)
+  getThumbnailUrl(record: UsersRecord, filename: string, size: '100x100' | '300x300' = '100x100'): string {
+    return `${pb.files.getURL(record, filename)}?thumb=${size}`
+  },
+}
+
+// Helpers específicos por feature (vertical slice)
+export const userFilesService = {
+  async uploadAvatar(userId: string, file: File) {
+    return filesService.uploadToRecord<UsersRecord>('users', userId, 'avatar', file)
+  },
+  getAvatarUrl(user: UsersRecord): string | null {
+    return user.avatar ? filesService.getUrl(user, user.avatar) : null
+  },
+}
+```
+
+> ⚠️ **Padrão 3 em ação**: arquivos privados (anexos confidenciais) exigem `listRule: ""` na collection + endpoint `/api/files/signed-token` que valida permissão antes de emitir token temporário.
+
 ## Caso 1 — Avatar do user
 
 ### Adicionar campo à collection `users`

--- a/.opencode/skills/evolution-roadmap/SKILL.md
+++ b/.opencode/skills/evolution-roadmap/SKILL.md
@@ -7,6 +7,20 @@ description: Estratégia macro de evolução do projeto no template pocketbase-v
 
 O template é um **canivete suíço**. Sem um roadmap, você perde tempo construindo a coisa errada. Esta skill é a visão macro — combine com as **skills técnicas** (vue-pinia-store, vue-router-auth…) e **skills de domínio** (domain-crm-leads, domain-saas-billing…) pra implementar.
 
+## 🏛️ Padrões arquiteturais (leia antes de começar)
+
+Antes da Fase 0, leia a seção [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada) do README. Os 5 padrões são pré-requisitos de qualquer fase abaixo:
+
+| # | Padrão | Por que importa aqui |
+|---|---|---|
+| 1 | Camada de Service | Toda fase que criar feature precisa disso |
+| 2 | Service thin + hook custom | Decide o que vai no service vs hook |
+| 3 | Backend = verdade | Define regras de acesso em toda collection nova |
+| 4 | Vertical slicing | Decide estrutura de pastas na Fase 2 |
+| 5 | Type-safety | Decide setup de tsconfig + types na Fase 0/1 |
+
+Este roadmap assume que esses padrões estão sendo seguidos. Se você está construindo sem service layer ou sem collection rules, **volte e aplique os padrões primeiro** — qualquer feature em cima vai ter dívida técnica desde o dia 1.
+
 ## Fases recomendadas
 
 ```
@@ -56,10 +70,12 @@ Aqui é onde o app se diferencia. **Comece pelo modelo de dados**, não pela UI.
 
 1. **Desenhar 1-3 collections core** (ex: CRM → `leads`, `contacts`, `activities`)
 2. **Criar migrations JS** (versionadas no git)
-3. **Configurar regras de acesso** (CRUD por ownership)
-4. **Stub do Pinia store** (mesmo antes da UI)
-5. **1 view CRUD mínima** (lista + form) — validar fluxo end-to-end
-6. **Depois polir** (filtros, paginação, validações, UX)
+3. **Configurar regras de acesso** (CRUD por ownership) — **Padrão 3**
+4. **Criar a estrutura de pastas da feature** (vertical slice, se já tem 3+ features) — **Padrão 4**
+5. **Criar o service layer** (`features/<x>/services/<x>.service.ts`) — **Padrão 1 + 2**
+6. **Stub do Pinia store** que consome o service (não o pb direto) — **Padrão 1**
+7. **1 view CRUD mínima** (lista + form) — validar fluxo end-to-end
+8. **Depois polir** (filtros, paginação, validações, UX)
 
 ### Qual domínio?
 
@@ -110,9 +126,10 @@ Típico adicionar nessa fase:
 
 ## Ordem sugerida de skills pra um projeto novo
 
+0. **README → seção [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada)** → entender os 5 padrões antes de qualquer linha de código
 1. `pocketbase-template-scaffold` → setup
-2. `pocketbase-collections` → modelagem base
-3. `vue-pinia-store` → state management
+2. `pocketbase-collections` → modelagem base (Padrões 2 e 3)
+3. `vue-pinia-store` → state management com service layer (Padrões 1 e 5)
 4. `vue-router-auth` → rotas/guards
 5. `tailwind-vue-component` → UI
 6. `domain-<seu-caso>` → feature end-to-end

--- a/.opencode/skills/pocketbase-collections/SKILL.md
+++ b/.opencode/skills/pocketbase-collections/SKILL.md
@@ -7,6 +7,17 @@ description: Criar, migrar e estender collections/hooks do PocketBase no templat
 
 PocketBase é o backend do template. Tudo passa pelo admin (`/_/`) + JS hooks em `pocketbase/pb_hooks/`.
 
+## 🏛️ Alinhamento com Arquitetura Recomendada
+
+Esta skill é a **implementação dos Padrões 2 e 3** da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada):
+
+| Padrão | Aplicação nesta skill |
+|---|---|
+| 2 — Service thin + hook | Define onde mora cada tipo de lógica (CRUD vs multi-collection). Service no front é thin wrapper; hooks PB pra lógica complexa. |
+| 3 — Backend é a verdade | Toda collection **deve** ter `listRule`/`viewRule`/`createRule`/`updateRule`/`deleteRule` definidos. Front só esconde UI por UX, nunca por segurança. |
+
+> ⚠️ **Mudança conceitual**: collection rules **não são opcionais**. Antes desta skill dizia "recomendado pra esse template". Agora é **obrigatório** em produção multi-user. Collection com `null` nas rules = acesso público irrestrito. Não vai pra prod assim.
+
 ## Localização dos arquivos
 
 ```
@@ -51,22 +62,97 @@ migrate((db) => {
 
 3. **Tipos TS**: o PB gera `pb_data/types.d.ts` em runtime. Pra forçar: rode `npm run dev:pb` por 1-2s e olhe o arquivo.
 
-## Regras de acesso (recomendado pra esse template)
+## Regras de acesso (OBRIGATÓRIO)
 
-| Collection | List | View | Create | Update | Delete |
-|------------|------|------|--------|--------|--------|
-| `posts`    | ✓ auth | ✓ auth | author = @request.auth.id | author = @request.auth.id | author = @request.auth.id |
-| `users`    | self only | self only | admin | self | self |
+Toda collection nova **deve** ter as 5 regras (`listRule`, `viewRule`, `createRule`, `updateRule`, `deleteRule`) explicitamente definidas — nunca `null` em produção multi-user. `null` = público irrestrito.
 
-Use a UI do admin ou na migration, campo `listRule`, `viewRule`, etc:
+### Templates prontos
+
+**SaaS multi-user (dono-edita-seus-dados)** — caso mais comum:
 
 ```js
-listRule:   "author = @request.auth.id",
-viewRule:   "author = @request.auth.id",
-createRule: "@request.auth.id != ''",
-updateRule: "author = @request.auth.id",
-deleteRule: "author = @request.auth.id",
+listRule:   "author = @request.auth.id",      // vê só os próprios
+viewRule:   "author = @request.auth.id || @request.auth.isAdmin",  // admin vê tudo
+createRule: "@request.auth.id != ''",         // qualquer logado cria
+updateRule: "author = @request.auth.id",      // só dono edita
+deleteRule: "author = @request.auth.id",      // só dono deleta
 ```
+
+**Conteúdo público (blog, docs, landing)** — leitura aberta, escrita fechada:
+
+```js
+listRule:   "status = \"published\" || @request.auth.isAdmin",
+viewRule:   "status = \"published\" || @request.auth.isAdmin",
+createRule: "@request.auth.id != ''",          // logado pode criar (vai pra draft)
+updateRule: "author = @request.auth.id || @request.auth.isAdmin",
+deleteRule: "@request.auth.id.isAdmin || author = @request.auth.id",
+```
+
+**Admin-only (audit log, settings, métricas)** — ninguém vê, exceto admin:
+
+```js
+listRule:   "@request.auth.isAdmin",
+viewRule:   "@request.auth.isAdmin",
+createRule: "",                                // vazio = ninguém cria via API
+updateRule: "@request.auth.isAdmin",
+deleteRule: "@request.auth.isAdmin",
+```
+
+> 💡 Para `createRule: ""` em audit_log (append-only), criar via hook server-side com `$app.dao().saveRecord()` (sem check de rule).
+
+**Team/multi-tenant (time vê dados do time)** — Padrão 4 aplicado:
+
+```js
+listRule:   "team = @request.auth.team",
+viewRule:   "team = @request.auth.team",
+createRule: "@request.auth.id != '' && team = @request.auth.team",
+updateRule: "(team = @request.auth.team) && (author = @request.auth.id || @request.auth.isAdmin)",
+deleteRule: "@request.auth.isAdmin",
+```
+
+### Onde aplicar
+
+**Via migration JS** (preferido, versionado no git):
+
+```js
+const collection = new Collection({
+  name: 'posts',
+  type: 'base',
+  schema: [/* ... */],
+  listRule:   "author = @request.auth.id",
+  viewRule:   "author = @request.auth.id || @request.auth.isAdmin",
+  createRule: "@request.auth.id != ''",
+  updateRule: "author = @request.auth.id",
+  deleteRule: "author = @request.auth.id || @request.auth.isAdmin",
+})
+```
+
+**Via admin UI** (debug local): `/_/` → editar collection → abas "Access rules". Sempre replicar pra migration depois (git é a fonte da verdade).
+
+### Checklist obrigatório por collection
+
+Antes de commitar uma migration com collection nova:
+
+- [ ] `listRule` definido (não `null`)
+- [ ] `viewRule` definido (não `null`)
+- [ ] `createRule` definido (não `null`)
+- [ ] `updateRule` definido (não `null`)
+- [ ] `deleteRule` definido (não `null`)
+- [ ] `@request.auth.isAdmin` adicionado onde admin precisa bypass
+- [ ] Regras cobertas pelo hook server-side validam campos críticos (ex: `onRecordBeforeCreateRequest` pra validar invariantes)
+- [ ] Testado: tenta `curl` sem token / com user errado → **deve** dar 401/403/404
+- [ ] Migration tem campos `created` + `updated` (Padrão JSVM: UI cria auto, JSVM não)
+
+### Anti-pattern: regras permissivas demais
+
+| ❌ Errado | Por que | ✅ Certo |
+|---|---|---|
+| `listRule: null` | público irrestrito | `"author = @request.auth.id"` |
+| `createRule: null` | qualquer um cria | `"@request.auth.id != ''"` |
+| `deleteRule: null` | qualquer um deleta | `"author = @request.auth.id \|\| @request.auth.isAdmin"` |
+| Confiar só em hook | hook roda, mas list já vazou | collection rules + hook (defense in depth) |
+| Regras só no front | burlável via curl/Postman | regras **sempre** no PB |
+
 
 ## Hooks
 
@@ -100,23 +186,118 @@ Tipos comuns de hook:
 
 > Hooks são recarregados automaticamente pelo PB quando você salva o arquivo. Não precisa reiniciar.
 
-## Consumindo no Vue (TS tipado)
+## Consumindo no Vue (TS tipado, via service layer)
 
-```ts
-// apps/web/src/stores/posts.ts
-import pb from '@/services/pocketbase'
-import type { PostsRecord } from '../../../pocketbase/pb_data/types'
+> 📖 **Service layer é obrigatório** (Padrão 1 da Arquitetura Recomendada). Store/componente **nunca** fala com `pb` direto. Sempre passa por `*.service.ts`.
 
-export async function listPosts() {
-  return pb.collection('posts').getList<PostsRecord>(1, 20)
-}
+### Estrutura recomendada (vertical slice por feature)
 
-export async function createPost(data: { title: string; body: string }) {
-  return pb.collection('posts').create(data)
+```
+apps/web/src/features/<feature>/
+├── components/
+├── stores/<feature>.store.ts        ← consome o service
+├── services/<feature>.service.ts    ← única camada que fala com pb
+├── composables/
+├── views/
+└── index.ts                          ← controla o que vaza
+```
+
+### Configurar alias `@pb-types` (uma vez)
+
+No `apps/web/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@pb-types/*": ["../../pocketbase/pb_data/types.d.ts"]
+    }
+  }
 }
 ```
 
-> ⚠️ o caminho relativo `../../../pocketbase/pb_data/types` é frágil — alternativa: configurar `paths` no `tsconfig.json` com `@pb-types/*` apontando pra `pocketbase/pb_data/types.d.ts`.
+> Rodar `npm run dev:pb` por 1-2s em outro terminal regenera `types.d.ts`.
+
+### Service (camada que fala com pb)
+
+```ts
+// apps/web/src/features/posts/services/posts.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PostsRecord } from '@pb-types'
+
+export const postsService = {
+  // CRUD — Padrão 1 + 2 (thin wrapper)
+  async list(page = 1, perPage = 20) {
+    return pb.collection('posts').getList<PostsRecord>(page, perPage)
+  },
+  async getById(id: string) {
+    return pb.collection('posts').getOne<PostsRecord>(id)
+  },
+  async create(data: Partial<PostsRecord>) {
+    return pb.collection('posts').create<PostsRecord>(data)
+  },
+  async update(id: string, data: Partial<PostsRecord>) {
+    return pb.collection('posts').update<PostsRecord>(id, data)
+  },
+  async delete(id: string) {
+    return pb.collection('posts').delete(id)
+  },
+
+  // Lógica avançada — Padrão 2 (endpoint custom no PB)
+  async publish(id: string) {
+    return pb.send(`/api/posts/${id}/publish`, { method: 'POST' })
+  },
+}
+```
+
+### Store (consome o service)
+
+```ts
+// apps/web/src/features/posts/stores/posts.store.ts
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { postsService } from '../services/posts.service'
+import type { PostsRecord } from '@pb-types'
+
+export const usePostsStore = defineStore('posts', () => {
+  const items = ref<PostsRecord[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchAll() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await postsService.list()
+      items.value = res.items
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao buscar posts'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function publish(id: string) {
+    const updated = await postsService.publish(id)
+    const i = items.value.findIndex(p => p.id === id)
+    if (i >= 0) items.value[i] = updated
+  }
+
+  return { items, loading, error, fetchAll, publish }
+})
+```
+
+### Anti-patterns de consumo
+
+| ❌ Errado | ✅ Certo |
+|---|---|
+| `pb.collection('posts').getList()` em store | `postsService.list()` em store |
+| Tipo `RecordModel` (genérico) | Tipo `PostsRecord` (do PB, via `@pb-types`) |
+| `any` no payload/retorno | Tipo do PB ou interface local |
+| Path relativo `../../../pocketbase/...` | Alias `@pb-types` |
+| Componente chama `pb.collection()` direto | Componente → store → service → pb |
+
 
 ## Deploy com collections/migrações
 

--- a/.opencode/skills/vue-pinia-store/SKILL.md
+++ b/.opencode/skills/vue-pinia-store/SKILL.md
@@ -7,44 +7,109 @@ description: Criar Pinia stores no padrão do template pocketbase-vue-tailwind �
 
 O template usa **Composition API stores** (não Options API) com tipagem vinda do PocketBase. Veja `apps/web/src/stores/auth.ts` como referência canônica.
 
+## 🏛️ Padrão arquitetural: Service Layer (leia antes)
+
+Stores **nunca** falam com `pb.collection()` ou `pb.send()` direto. A única camada autorizada a tocar o backend é o **service** (`features/<x>/services/<x>.service.ts`).
+
+```
+component / store
+        ↓
+  service.ts           ← única camada que fala com o backend
+        ↓
+   PocketBase (CRUD direto OU hook custom via /api/...)
+```
+
+**Por quê** (Padrão 1 da [Arquitetura Recomendada](../../README.md#-arquitetura-recomendada)):
+- Trocar de stack = reescrever 1 arquivo por feature
+- Validação/normalização centralizada
+- Auditabilidade
+
+**Como o service se divide** (Padrão 2):
+- Operações **single-collection CRUD padrão** → `pb.collection().X()` direto no service
+- Operações **multi-collection / efeito externo / validação complexa** → `pb.send('/api/...')` → hook custom no PB
+
+A store abaixo está errada. **A forma correta vem na seção seguinte.**
+
+```ts
+// ❌ ERRADO: store fala com pb direto
+export const usePostsStore = defineStore('posts', () => {
+  async function fetchAll() {
+    const res = await pb.collection('posts').getList()  // ← não
+  }
+})
+```
+
+```ts
+// ✅ CERTO: store fala com service
+import { postsService } from '../services/posts.service'
+
+export const usePostsStore = defineStore('posts', () => {
+  async function fetchAll() {
+    const res = await postsService.list()  // ← sim
+  }
+})
+```
+
+> 📖 Detalhes do service (estrutura, quando usar hook custom, exemplos completos) na skill [`pocketbase-collections`](../pocketbase-collections/SKILL.md).
+
 ## Estrutura canônica
 
 ```ts
 // apps/web/src/stores/<nome>.ts
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import pb from '../services/pocketbase'
-import type { RecordModel } from 'pocketbase' // ou tipo gerado do PB
+import { postsService } from '../services/posts.service'  // ← service, nunca pb direto
+import type { PostsRecord } from '@pb-types'              // ← tipo do PB, nunca any
 
 export const usePostsStore = defineStore('posts', () => {
   // ---- state (refs)
-  const items = ref<RecordModel[]>([])
+  const items = ref<PostsRecord[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
 
   // ---- getters
   const count = computed(() => items.value.length)
 
-  // ---- actions
+  // ---- actions — falam com o service, não com o pb
   async function fetchAll() {
     loading.value = true
     error.value = null
     try {
-      const res = await pb.collection('posts').getList(1, 50, { sort: '-created' })
+      const res = await postsService.list()
       items.value = res.items
-    } catch (e: any) {
-      error.value = e?.message || 'Falha ao buscar posts'
+    } catch (e: unknown) {
+      error.value = e instanceof Error ? e.message : 'Falha ao buscar posts'
     } finally {
       loading.value = false
     }
   }
 
-  async function create(data: { title: string; body: string }) {
-    return pb.collection('posts').create(data)
+  async function create(data: Partial<PostsRecord>) {
+    const created = await postsService.create(data)
+    items.value.push(created)
+    return created
   }
 
   return { items, loading, error, count, fetchAll, create }
 })
+```
+
+E o service correspondente (referência — completo na skill [`pocketbase-collections`](../pocketbase-collections/SKILL.md)):
+
+```ts
+// apps/web/src/features/posts/services/posts.service.ts
+import pb from '@/shared/services/pocketbase'
+import type { PostsRecord } from '@pb-types'
+
+export const postsService = {
+  async list(page = 1, perPage = 50) {
+    return pb.collection('posts').getList<PostsRecord>(page, perPage, { sort: '-created' })
+  },
+  async create(data: Partial<PostsRecord>) {
+    return pb.collection('posts').create<PostsRecord>(data)
+  },
+  // ...
+}
 ```
 
 Regras do template:
@@ -144,3 +209,4 @@ async function create(data) {
 | Mutação direta de `pb.authStore` | Chamar `auth.login()` ou `auth.logout()` |
 | `any` no payload/retorno | Tipo do PB ou interface local |
 | `watchEffect` sincronizando auth | `pb.authStore.onChange` |
+| **Store fala com `pb.collection()` direto** | **Store fala com `*.service.ts`** |

--- a/README.md
+++ b/README.md
@@ -66,6 +66,142 @@ pocketbase-vue-tailwind-template/
 └── README.md
 ```
 
+## 🏛️ Arquitetura Recomendada
+
+Estes 5 padrões se aplicam a **qualquer app** construído a partir deste template (blog, CRM, SaaS, helpdesk, e-commerce, painel admin, marketplace, etc). Cada skill em `.opencode/skills/` implementa esses padrões dentro do seu domínio — comece pela skill [`evolution-roadmap`](./.opencode/skills/evolution-roadmap/SKILL.md) pra visão macro de quando aplicar cada um.
+
+### Padrão 1 — Camada de Service (sempre)
+
+**Regra**: nenhum store ou componente chama `pb.collection()` ou `pb.send()` direto. Toda chamada passa por um `*.service.ts` por feature.
+
+```
+component / store
+        ↓
+  service.ts            ← única camada que fala com o backend
+        ↓
+   PocketBase (CRUD direto OU hook custom)
+```
+
+**Por quê**:
+- Trocar de stack = reescrever 1 arquivo por feature
+- Validação/normalização centralizada
+- Auditabilidade (1 lugar pra ver tudo que o front pede)
+
+**Custo**: ~30 linhas por feature. Retorno: vale sempre.
+
+---
+
+### Padrão 2 — Service thin + hook custom pra lógica avançada
+
+**Regra dentro do service**:
+
+| Tipo de operação | Como implementar |
+|---|---|
+| Single-collection, CRUD padrão | `pb.collection('x').getList()` direto |
+| Multi-collection, efeito externo, validação complexa, atomicidade | `pb.send('/api/...')` → hook custom no `pb_hooks/` |
+
+**Como decidir entre as duas** — pergunte nessa ordem:
+
+1. **Se o usuário burlar o front, o que acontece?**
+   - Dá ruim (dado inconsistente, vazamento) → endpoint custom no PB
+   - Só UX ruim → pode ser direto
+2. **Mais de um lugar precisa rodar essa lógica?**
+   - Sim (web app + admin + cron + mobile) → endpoint custom
+   - Só um lugar → pode ser direto
+3. **É regra de acesso ou integridade do dado?**
+   - Sim → sempre no PB
+
+**Exemplos domain-agnostic**:
+- Blog: `criar post` (CRUD) vs `publicar post + notificar subscribers + indexar busca` (hook)
+- E-commerce: `add ao carrinho` (CRUD) vs `finalizar compra` (carrinho + pedido + pagamento + email)
+- Helpdesk: `criar ticket` (CRUD) vs `atribuir técnico` (ticket + notificação + log)
+
+---
+
+### Padrão 3 — Backend é a fonte da verdade de acesso
+
+**Regra**: toda collection tem `listRule`, `viewRule`, `createRule`, `updateRule`, `deleteRule` definidos (nunca `null` em produção multi-user).
+
+```js
+// padrão SaaS multi-user
+listRule:   "owner = @request.auth.id",
+viewRule:   "owner = @request.auth.id",
+createRule: "@request.auth.id != ''",
+updateRule: "owner = @request.auth.id",
+deleteRule: "owner = @request.auth.id"
+```
+
+**Frontend só esconde UI por UX, nunca por segurança.** Quem curl + admin token pode chamar a API direto — o PB barra via rules.
+
+**Exceção**: apps single-user/admin local podem relaxar, mas é raro.
+
+---
+
+### Padrão 4 — Vertical slicing quando crescer
+
+**Regra**: começar com a estrutura horizontal padrão do template. Migrar pra vertical quando:
+- App tem 3+ features distintas
+- Time/pessoa perdendo tempo achando arquivo
+- Vai começar a deletar/refatorar features
+
+**Estrutura alvo**:
+```
+apps/web/src/
+├── features/
+│   ├── <feature-a>/
+│   │   ├── components/
+│   │   ├── stores/<feature>.store.ts
+│   │   ├── services/<feature>.service.ts    ← sempre
+│   │   ├── composables/
+│   │   ├── views/
+│   │   └── index.ts                          ← controla o que vaza
+│   └── <feature-b>/
+├── shared/
+│   ├── components/         ← só o que é reusado por 2+ features
+│   └── services/pocketbase.ts
+└── router/
+```
+
+**Ganho**: deletar uma feature = deletar uma pasta. Sem caça ao tesouro.
+
+---
+
+### Padrão 5 — Type-safety ponta-a-ponta
+
+**Regra**:
+- Tipos vêm do PB (`pb_data/types.d.ts`, gerado em runtime)
+- Alias `@pb-types` configurado no `tsconfig.json`
+- Zero `any` em store/service
+- `env.d.ts` declara todas as `VITE_*` pra autocomplete
+
+```json
+// apps/web/tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"],
+      "@pb-types/*": ["../../pocketbase/pb_data/types.d.ts"]
+    }
+  }
+}
+```
+
+**Custo**: configuração única. Retorno: refactor seguro, autocomplete, bugs pegos em compile time.
+
+---
+
+### Mapa: Padrão × Skill
+
+| Padrão | Skill primária | Skills relacionadas |
+|---|---|---|
+| 1 — Camada de service | [`vue-pinia-store`](./.opencode/skills/vue-pinia-store/SKILL.md) | todas as de domínio |
+| 2 — Service thin + hook | [`pocketbase-collections`](./.opencode/skills/pocketbase-collections/SKILL.md) | [`evolution-roadmap`](./.opencode/skills/evolution-roadmap/SKILL.md) |
+| 3 — Backend = verdade | [`pocketbase-collections`](./.opencode/skills/pocketbase-collections/SKILL.md) | todas as de domínio |
+| 4 — Vertical slicing | [`evolution-roadmap`](./.opencode/skills/evolution-roadmap/SKILL.md) | — |
+| 5 — Type-safety | [`vue-pinia-store`](./.opencode/skills/vue-pinia-store/SKILL.md) | [`vite-env-config`](./.opencode/skills/vite-env-config/SKILL.md) |
+
+> 💡 **Ordem sugerida de leitura**: `evolution-roadmap` (visão macro) → `pocketbase-collections` (Padrões 2 e 3) → `vue-pinia-store` (Padrões 1 e 5) → `vue-router-auth` (complementar) → skills de domínio específicas do seu app.
+
 ## 🛠️ Pré-requisitos
 
 - **Node.js** >= 20.19.0


### PR DESCRIPTION
## Resumo

Adiciona documentação arquitetural universal no README e alinha **todas as 13 skills** + cria 1 nova skill. Stores de exemplo nas skills `domain-*` foram refatoradas para consumir **service layer** (Padrão 1) em vez de `pb.collection()` direto.

## Entregáveis (16 commits)

### 1. README — nova seção "Arquitetura Recomendada"
Documenta os **5 padrões universais**: Camada de Service, Service thin + hook, Backend é a verdade, Vertical slicing, Type-safety.

### 2. Skill `vue-pinia-store` — alinhada aos Padrões 1, 2 e 5
Service Layer como padrão arquitetural antes da estrutura canônica.

### 3. Skill `evolution-roadmap` — alinhada à nova arquitetura
Padrões como pré-requisito; Fase 2 atualizada com service layer + vertical slicing.

### 4-12. Skills `domain-*` (9 skills) — bloco de alinhamento
Cada uma com tabela Padrão × Aplicação + service layer de exemplo.

### 13. Skill `pocketbase-collections` — Fase 2
- Promote collection rules de 'recomendado' para OBRIGATÓRIO
- 4 templates prontos (SaaS, público, admin-only, multi-tenant)
- Checklist de 9 itens por collection
- Refatora 'Consumindo no Vue' com service layer + alias @pb-types

### 14. Nova skill `domain-feature-scaffold` — Fase 3
Receita canônica de 7 passos pra adicionar feature end-to-end seguindo os 5 padrões (migration → service → store → view → hooks opcionais).

### 15-16. Refatoração de stores (Fase 4)
Stores de **8 skills domain-*** agora consomem service em vez de `pb.collection()` direto:

| Skill | Mudança |
|---|---|
| `domain-blog-cms` | usePostsStore + postsService (incrementView via hook) |
| `domain-admin-panel` | useAdminStore + adminService (invite/reset/impersonate via hooks) |
| `domain-realtime` | useKanbanStore + realtimeService compartilhado |
| `domain-crm-leads` | useLeadsStore + leadsService + leadsRealtime (convertToClient via hook) |
| `domain-rbac` | useAdminUsersStore + adminUsersService |
| `domain-saas-billing` | useEntitlementsStore + billingService |
| `domain-email-hooks` | notificationPrefsService + view refatorada |
| `domain-storage-files` | Avatar/attachments/signed URL via services |

**Mudanças aplicadas consistentemente**:
- Service em `features/<x>/services/<x>.service.ts`
- Store com `try/catch` tipado (`unknown` + `instanceof Error`, sem `any`)
- Tipo do PB via `@pb-types` (em vez de `any`/`RecordModel`)
- Tipos auxiliares via union (`Role`, `Status`) em vez de strings soltas
- Subscribe realtime encapsulado em service compartilhado
- `try/finally` garante `loading = false`

## Compatibilidade

- Não altera código de produção (apps/)
- Não altera migrations
- Não altera package.json / dependências
- Mudanças **puramente documentais** (arquivos `.md` apenas)

## Estatísticas

- **16 commits** na branch
- **14 arquivos** modificados + 1 novo (`domain-feature-scaffold`)
- Mudanças de docs apenas — **zero risco** de quebrar build/runtime

## Próximos passos (PRs futuros sugeridos)

1. **PR #N+1**: aplicar o mesmo service layer refactor nos stores Pinia em `apps/web/src/stores/` (não nas skills, mas no template real)
2. **PR #N+2**: criar migration template com todos os campos obrigatórios (created, updated, owner) + collection rules SaaS multi-user como padrão
3. **PR #N+3**: criar script `npm run new-feature` que escaffolda `features/<name>/` seguindo o workflow de `domain-feature-scaffold`